### PR TITLE
Add flag and code to disable streamline edges

### DIFF
--- a/src/benbria-configure-ninja.coffee
+++ b/src/benbria-configure-ninja.coffee
@@ -210,6 +210,11 @@ makeNinja = (options, done) ->
 
     ninja = ninjaBuilder('1.3', 'build')
 
+    if options.disableStreamline
+        log.warn 'disabling streamline as requested.'
+        factories.filterFactories (factory) ->
+            !(/streamline/i.test(factory.name))
+
     factories.forEachFactory (factory) ->
         factory.initialize?(ninja, config, log)
 
@@ -295,6 +300,12 @@ getOptions = ->
         dest: "streamlineOpts"
         defaultValue: ''
 
+    parser.addArgument [ '--disable-streamline' ],
+        help: "Turn off streamline compiling completely"
+        metavar: "opts"
+        dest: "disableStreamline"
+        action: 'storeTrue'
+
     parser.addArgument [ '--stylus-opts' ],
         help: "Extra options for stylus"
         metavar: "opts"
@@ -329,6 +340,7 @@ module.exports = (configureNinjaScript) ->
 
     if options.streamline8 then config.streamlineVersion = 8
     config.streamlineOpts = options.streamlineOpts
+    config.disableStreamline = options.disableStreamline
     config.stylusOpts = options.stylusOpts
 
     if options.require

--- a/src/ninjaFactories.coffee
+++ b/src/ninjaFactories.coffee
@@ -76,6 +76,10 @@ exports.forEachFactory = (fn) ->
     for factory in allFactories
         fn(factory)
 
+# Run a filter fn on the factories to remove some
+exports.filterFactories = (fn) ->
+    allFactories = allFactories.filter fn
+
 # Run a command for every factory available.
 exports.forActiveFactory = (config, log, fn) ->
     for factory in allFactories


### PR DESCRIPTION
`loop-common` and `loop-reporting` both use this to build themselves. There are some extra flags that need to be added to make `streamlinejs` >= 1.x work. Namely, `--runtime callbacks`, `--quiet`. I tried just adding these to the config file, however streamline also changed `-o` to `-d` and it seems to ignore it, and builds the files in place. *sigh*. 

This change allows a project to ignore its streamline edges and handle them on their own. 

I'm suggesting this change so we can just use the streamline command line tool through `npm run` in `loop-reporting`. I completely removed `ninja` and `benbria-build` from loop-common and just used the command line tools via `npm`. 